### PR TITLE
EGL/egl.h: Include img_defs.h to get IMG_EXPORT

### DIFF
--- a/include/EGL/egl.h
+++ b/include/EGL/egl.h
@@ -24,6 +24,7 @@
 #endif
 
 #ifndef APIENTRY
+#include <gpu_es4/eurasia/include4/img_defs.h>
 #define APIENTRY IMG_CALLCONV
 #endif
 


### PR DESCRIPTION
Fixes #19 

An alternative is to simply do the following in `EGL/egl.h`:
```c
#define APIENTRY
```